### PR TITLE
tests/report: Remove report-perf_heatmap test

### DIFF
--- a/tests/report/test.sh
+++ b/tests/report/test.sh
@@ -44,12 +44,6 @@ test_report "$damo report heats --guide" "heats_guide"
 
 test_report "$damo report heats" "heats"
 
-if perf script -l | grep -q damon
-then
-	test_report "perf script report damon -i perf.data heatmap" \
-		"perf_heatmap"
-fi
-
 rm -fr results
 
 echo "PASS" $(basename $(pwd))


### PR DESCRIPTION
Doing test of perf in DAMO makes no sense.  Remove it.

Signed-off-by: SeongJae Park <sj38.park@gmail.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
