### PR TITLE
Make 'schemes' receive schemes as a string from the command line

### DIFF
--- a/_convert_damos.py
+++ b/_convert_damos.py
@@ -222,7 +222,9 @@ def main():
     aggr_interval = args.aggr
     scheme_ver = args.scheme_version
 
-    print(convert(schemes_file, sample_interval, aggr_interval, scheme_ver))
+    with open(schemes_file, 'r') as f:
+        print(convert_txt(f.read(), sample_interval, aggr_interval,
+            scheme_ver))
 
 if __name__ == '__main__':
     main()

--- a/_convert_damos.py
+++ b/_convert_damos.py
@@ -36,6 +36,7 @@ schemes written in the human readable format:
 """
 
 import argparse
+import os
 import platform
 
 uint_max = 2**32 - 1
@@ -202,8 +203,8 @@ def convert(schemes, sample_interval, aggr_interval, scheme_version):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('input', metavar='<file>',
-            help='input file describing the schemes')
+    parser.add_argument('input', metavar='<file or schemes in text>',
+            help='input file describing the schemes or the schemes')
     parser.add_argument('-s', '--sample', metavar='<interval>', type=int,
             default=5000, help='sampling interval (us)')
     parser.add_argument('-a', '--aggr', metavar='<interval>', type=int,
@@ -212,14 +213,15 @@ def main():
             choices=range(0, 5), default=4, help='destination scheme version')
     args = parser.parse_args()
 
-    schemes_file = args.input
+    schemes_input = args.input
     sample_interval = args.sample
     aggr_interval = args.aggr
     scheme_ver = args.scheme_version
 
-    with open(schemes_file, 'r') as f:
-        print(convert(f.read(), sample_interval, aggr_interval,
-            scheme_ver))
+    if os.path.isfile(schemes_input):
+        with open(schemes_input, 'r') as f:
+            schemes_input = f.read()
+    print(convert(schemes_input, sample_interval, aggr_interval, scheme_ver))
 
 if __name__ == '__main__':
     main()

--- a/_convert_damos.py
+++ b/_convert_damos.py
@@ -189,6 +189,10 @@ def debugfs_scheme(line, sample_interval, aggr_interval, scheme_version):
         exit(1)
 
 def convert(schemes, sample_interval, aggr_interval, scheme_version):
+    if os.path.isfile(schemes):
+        with open(schemes, 'r') as f:
+            schemes = f.read()
+
     raw_lines = schemes.split('\n')
     converted_lines = []
     for line in raw_lines:
@@ -213,15 +217,11 @@ def main():
             choices=range(0, 5), default=4, help='destination scheme version')
     args = parser.parse_args()
 
-    schemes_input = args.input
     sample_interval = args.sample
     aggr_interval = args.aggr
     scheme_ver = args.scheme_version
 
-    if os.path.isfile(schemes_input):
-        with open(schemes_input, 'r') as f:
-            schemes_input = f.read()
-    print(convert(schemes_input, sample_interval, aggr_interval, scheme_ver))
+    print(convert(args.input, sample_interval, aggr_interval, scheme_ver))
 
 if __name__ == '__main__':
     main()

--- a/_convert_damos.py
+++ b/_convert_damos.py
@@ -187,18 +187,23 @@ def debugfs_scheme(line, sample_interval, aggr_interval, scheme_version):
         print('Unsupported scheme version: %d' % scheme_version)
         exit(1)
 
+def convert_txt(schemes_txt, sample_interval, aggr_interval, scheme_version):
+    raw_lines = schemes_txt.split('\n')
+    converted_lines = []
+    for line in raw_lines:
+        if line.startswith('#'):
+            continue
+        line = line.strip()
+        if line == '':
+            continue
+        converted_lines.append(debugfs_scheme(line, sample_interval,
+            aggr_interval, scheme_version))
+    return '\n'.join(converted_lines)
+
 def convert(schemes_file, sample_interval, aggr_interval, scheme_version):
-    lines = []
     with open(schemes_file, 'r') as f:
-        for line in f:
-            if line.startswith('#'):
-                continue
-            line = line.strip()
-            if line == '':
-                continue
-            lines.append(debugfs_scheme(line, sample_interval, aggr_interval,
-                scheme_version))
-    return '\n'.join(lines)
+        return convert_txt(f.read(), sample_interval, aggr_interval,
+                scheme_version)
 
 def main():
     parser = argparse.ArgumentParser()

--- a/_convert_damos.py
+++ b/_convert_damos.py
@@ -187,8 +187,8 @@ def debugfs_scheme(line, sample_interval, aggr_interval, scheme_version):
         print('Unsupported scheme version: %d' % scheme_version)
         exit(1)
 
-def convert_txt(schemes_txt, sample_interval, aggr_interval, scheme_version):
-    raw_lines = schemes_txt.split('\n')
+def convert(schemes, sample_interval, aggr_interval, scheme_version):
+    raw_lines = schemes.split('\n')
     converted_lines = []
     for line in raw_lines:
         if line.startswith('#'):
@@ -199,11 +199,6 @@ def convert_txt(schemes_txt, sample_interval, aggr_interval, scheme_version):
         converted_lines.append(debugfs_scheme(line, sample_interval,
             aggr_interval, scheme_version))
     return '\n'.join(converted_lines)
-
-def convert(schemes_file, sample_interval, aggr_interval, scheme_version):
-    with open(schemes_file, 'r') as f:
-        return convert_txt(f.read(), sample_interval, aggr_interval,
-                scheme_version)
 
 def main():
     parser = argparse.ArgumentParser()
@@ -223,7 +218,7 @@ def main():
     scheme_ver = args.scheme_version
 
     with open(schemes_file, 'r') as f:
-        print(convert_txt(f.read(), sample_interval, aggr_interval,
+        print(convert(f.read(), sample_interval, aggr_interval,
             scheme_ver))
 
 if __name__ == '__main__':

--- a/schemes.py
+++ b/schemes.py
@@ -72,8 +72,8 @@ def set_argparser(parser):
     _damon.set_init_regions_argparser(parser)
     parser.add_argument('target', type=str, metavar='<target>',
             help='the target command or the pid to record')
-    parser.add_argument('-c', '--schemes', metavar='<file>', type=str,
-            default='damon.schemes',
+    parser.add_argument('-c', '--schemes', metavar='<file or schemes in text>',
+            type=str, default='damon.schemes',
             help='data access monitoring-based operation schemes')
     parser.add_argument('--numa_node', metavar='<node id>', type=int,
             help='if target is \'paddr\', limit it to the numa node')
@@ -103,8 +103,13 @@ def main(args=None):
 
     args.rbuf = 0
     args.out = 'null'
-    args.schemes = _convert_damos.convert(args.schemes, args.sample, args.aggr,
-            scheme_version)
+    if os.path.isfile(args.schemes):
+        with open(args.schemes, 'r') as f:
+            schemes_txt = f.read()
+    else:
+        schemes_txt = args.schemes
+    args.schemes = _convert_damos.convert_txt(schemes_txt, args.sample,
+            args.aggr, scheme_version)
     new_attrs = _damon.cmd_args_to_attrs(args)
     init_regions = _damon.cmd_args_to_init_regions(args)
     numa_node = args.numa_node

--- a/schemes.py
+++ b/schemes.py
@@ -103,12 +103,7 @@ def main(args=None):
 
     args.rbuf = 0
     args.out = 'null'
-    if os.path.isfile(args.schemes):
-        with open(args.schemes, 'r') as f:
-            schemes_txt = f.read()
-    else:
-        schemes_txt = args.schemes
-    args.schemes = _convert_damos.convert(schemes_txt, args.sample, args.aggr,
+    args.schemes = _convert_damos.convert(args.schemes, args.sample, args.aggr,
             scheme_version)
     new_attrs = _damon.cmd_args_to_attrs(args)
     init_regions = _damon.cmd_args_to_init_regions(args)

--- a/schemes.py
+++ b/schemes.py
@@ -108,8 +108,8 @@ def main(args=None):
             schemes_txt = f.read()
     else:
         schemes_txt = args.schemes
-    args.schemes = _convert_damos.convert_txt(schemes_txt, args.sample,
-            args.aggr, scheme_version)
+    args.schemes = _convert_damos.convert(schemes_txt, args.sample, args.aggr,
+            scheme_version)
     new_attrs = _damon.cmd_args_to_attrs(args)
     init_regions = _damon.cmd_args_to_init_regions(args)
     numa_node = args.numa_node

--- a/tests/convert_schemes/test.sh
+++ b/tests/convert_schemes/test.sh
@@ -6,7 +6,7 @@ cd "$bindir"
 damon_debugfs="/sys/kernel/debug/damon"
 damo="../../damo"
 
-test_convert() {
+test_convert_file() {
 	for input in ./inputs/*
 	do
 		for version in {0..4}
@@ -23,8 +23,31 @@ test_convert() {
 			fi
 		done
 	done
+	echo "PASS convert_schemes-file"
 }
 
-test_convert
+test_convert_txt() {
+	for input_file in ./inputs/*
+	do
+		for version in {0..4}
+		do
+			scheme_name=$(basename "$input_file")
+			expected=$(cat "./expects/$scheme_name.v$version")
+
+			input_txt=$(cat "$input_file")
+			converted=$(../../_convert_damos.py \
+				--scheme_version "$version" "$input_txt")
+			if [ ! "$expected" = "$converted" ]
+			then
+				echo "FAIL convert-schemes (for $input_file)"
+				exit 1
+			fi
+		done
+	done
+	echo "PASS convert_schemes-txt"
+}
+
+test_convert_file
+test_convert_txt
 
 echo "PASS $(basename $(pwd))"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR makes 'schemes' subcommand to receive the schemes as a string from the command line.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
