### PR TITLE
Fixed typo in DESIGN.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,7 +9,7 @@ Below shows how `damo` works with DAMON/DAMOS in kernel.
            ▼              │read/write
       ┌──────────┐        ▼
       │Monitoring│   ┌─────────┐       User space
-    ──┤  reuslt  ├───┤ debugfs ├─────────────────
+    ──┤  result  ├───┤ debugfs ├─────────────────
       │   file   │   └─┬─────┬─┘     Kernel space
       └──────────┘     │     │Operation scheme
            ▲           │     ▼


### PR DESCRIPTION
*Issue #, if available:*

There is a typo in DESIGN.md. "Monitoring reuslt file" should be "Monitoring result file"

![damo_DESIGN md typo](https://user-images.githubusercontent.com/37674041/147489313-8b338c74-4875-49f2-bf3d-e12f9a7600e0.png)

*Description of changes:*

Corrected the typo, changing 'reuslt' to 'result' in DESIGN.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
