### PR TITLE
_damon_args: Fix deducible_target variable name in deduce_target()

### DIFF
--- a/_damon_args.py
+++ b/_damon_args.py
@@ -169,7 +169,7 @@ def deduce_target(args):
         args.self_started_target = True
     else:
         try:
-            pid = int(args.deduce_target)
+            pid = int(args.deducible_target)
         except:
             return 'target \'%s\' is not supported' % args.deducible_target
     args.target_pid = pid


### PR DESCRIPTION
This sets the correct variable name deducible_target and fixes the function deduce_target().

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
