### PR TITLE
damo_record: Add --perf_path option and check its sanity

### DIFF
--- a/_damon_result.py
+++ b/_damon_result.py
@@ -197,6 +197,10 @@ def perf_script_to_damon_result(script_output):
     set_first_snapshot_start_time(result)
     return result, None
 
+def set_perf_path(perf_path):
+    global PERF
+    PERF = perf_path
+
 def parse_damon_result(result_file):
     script_output = None
     if subprocess.check_output(

--- a/_damon_result.py
+++ b/_damon_result.py
@@ -9,6 +9,8 @@ import time
 
 import _damon
 
+PERF = 'perf'
+
 class DAMONRegion:
     start = None
     end = None
@@ -205,7 +207,7 @@ def parse_damon_result(result_file):
         try:
             with open(os.devnull, 'w') as fnull:
                 script_output = subprocess.check_output(
-                        ['perf', 'script', '-i', result_file],
+                        [PERF, 'script', '-i', result_file],
                         stderr=fnull).decode()
         except:
             pass
@@ -336,11 +338,11 @@ def aggregate_snapshots(snapshots):
 record_requests = {}
 def start_monitoring_record(file_path, file_format, file_permission):
     try:
-        subprocess.check_output(['which', 'perf'])
+        subprocess.check_output(['which', PERF])
     except:
         return None, 'perf is not installed'
     pipe = subprocess.Popen(
-            ['perf', 'record', '-a', '-e', 'damon:damon_aggregated', '-o',
+            [PERF, 'record', '-a', '-e', 'damon:damon_aggregated', '-o',
                 file_path])
     record_requests[pipe] = [file_path, file_format, file_permission]
     return pipe, None

--- a/_damon_result.py
+++ b/_damon_result.py
@@ -10,6 +10,7 @@ import time
 import _damon
 
 PERF = 'perf'
+PERF_EVENT = 'damon:damon_aggregated'
 
 class DAMONRegion:
     start = None
@@ -201,6 +202,19 @@ def set_perf_path(perf_path):
     global PERF
     PERF = perf_path
 
+    # Test perf record for damon event
+    err = None
+    try:
+        subprocess.check_output(['which', PERF])
+        try:
+            subprocess.check_output([PERF, 'record', '-e', PERF_EVENT, '--', 'sleep', '0'],
+                                    stderr=subprocess.PIPE)
+        except:
+            err = 'perf record not working with "%s"' % PERF
+    except:
+        err = 'perf not found at "%s"' % PERF
+    return err
+
 def parse_damon_result(result_file):
     script_output = None
     if subprocess.check_output(
@@ -341,12 +355,8 @@ def aggregate_snapshots(snapshots):
 
 record_requests = {}
 def start_monitoring_record(file_path, file_format, file_permission):
-    try:
-        subprocess.check_output(['which', PERF])
-    except:
-        return None, 'perf is not installed'
     pipe = subprocess.Popen(
-            [PERF, 'record', '-a', '-e', 'damon:damon_aggregated', '-o',
+            [PERF, 'record', '-a', '-e', PERF_EVENT, '-o',
                 file_path])
     record_requests[pipe] = [file_path, file_format, file_permission]
     return pipe, None

--- a/damo_record.py
+++ b/damo_record.py
@@ -97,6 +97,8 @@ def set_argparser(parser):
             default='record', help='output file\'s type')
     parser.add_argument('--output_permission', type=str, default='600',
             help='permission of the output file')
+    parser.add_argument('--perf_path', type=str, default='perf',
+            help='path of perf tool ')
     return parser
 
 def main(args=None):
@@ -112,6 +114,9 @@ def main(args=None):
     damon_record_supported = chk_handle_record_feature_support(args)
     output_permission = chk_handle_output_permission(args.output_permission)
     backup_duplicate_output_file(args.out)
+
+    # Set perf path in _damon_result
+    _damon_result.set_perf_path(args.perf_path)
 
     # Setup for cleanup
     set_data_for_cleanup(data_for_cleanup, args, output_permission)

--- a/damo_record.py
+++ b/damo_record.py
@@ -115,8 +115,11 @@ def main(args=None):
     output_permission = chk_handle_output_permission(args.output_permission)
     backup_duplicate_output_file(args.out)
 
-    # Set perf path in _damon_result
-    _damon_result.set_perf_path(args.perf_path)
+    # Set perf path and check its sanity
+    err = _damon_result.set_perf_path(args.perf_path)
+    if err != None:
+        print(err)
+        cleanup_exit(-3)
 
     # Setup for cleanup
     set_data_for_cleanup(data_for_cleanup, args, output_permission)


### PR DESCRIPTION
This PR adds `--perf_path` option for damo record to provide a way to
change the file path of perf.

In addition, the current way of testing perf is to check whether perf exists or not.

However, if the perf record doesn't work properly, then there is no need
to proceed to the actual damo record.

This PR also makes damo record to check whether the given perf binary
actually works.

Here are the example executions.
```
  $ ls /xxx/perf
  ls: cannot access '/xxx/perf': No such file or directory

  $ sudo ./damo record --perf_path=/xxx/perf $$
  perf not found at "/xxx/perf"

  $ file /usr/bin/perf
  /usr/bin/perf: Bourne-Again shell script, ASCII text executable

  $ sudo ./damo record --perf_path=/usr/bin/perf $$
  perf record not working with "/usr/bin/perf"

  $ file /home/honggyu/usr/bin/perf
  /home/honggyu/usr/bin/perf: ELF 64-bit LSB pie executable, x86-64, ...

  $ sudo ./damo record --perf_path=/home/honggyu/usr/bin/perf $$
  Press Ctrl+C to stop
  ^C
  signal 2 received
  [ perf record: Woken up 1 times to write data ]
  [ perf record: Captured and wrote 1.483 MB damon.data (153 samples) ]
```
Fixed: #38 