### PR TITLE
_damon_result: Do not return error in start_monitoring_record

### DIFF
--- a/_damon_result.py
+++ b/_damon_result.py
@@ -356,10 +356,9 @@ def aggregate_snapshots(snapshots):
 record_requests = {}
 def start_monitoring_record(file_path, file_format, file_permission):
     pipe = subprocess.Popen(
-            [PERF, 'record', '-a', '-e', PERF_EVENT, '-o',
-                file_path])
+            [PERF, 'record', '-a', '-e', PERF_EVENT, '-o', file_path])
     record_requests[pipe] = [file_path, file_format, file_permission]
-    return pipe, None
+    return pipe
 
 def stop_monitoring_record(perf_pipe):
     file_path, file_format, file_permission = record_requests[perf_pipe]

--- a/damo_record.py
+++ b/damo_record.py
@@ -138,12 +138,9 @@ def main(args=None):
 
     if not damon_record_supported or is_ongoing:
         # Record the monitoring results using perf
-        data_for_cleanup.perf_pipe, err = _damon_result.start_monitoring_record(
+        data_for_cleanup.perf_pipe = _damon_result.start_monitoring_record(
                 data_for_cleanup.rfile_path, data_for_cleanup.rfile_format,
                 data_for_cleanup.rfile_permission)
-        if err != None:
-            print('could not start recording (%s)' % err)
-            cleanup_exit(-3)
     print('Press Ctrl+C to stop')
 
     if _damon_args.self_started_target(args):


### PR DESCRIPTION
The following commit removed returning error message in _damon_result.start_monitoring_record.

  fcac3e0 _damon_result: Enhance set_perf_path with perf record test

So there's no need to return error code here and it can be removed.