### PR TITLE
Remove shebangs from non-executable Python files

### DIFF
--- a/_damo_dist.py
+++ b/_damo_dist.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import os

--- a/_damo_fmt_str.py
+++ b/_damo_fmt_str.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import platform

--- a/_damo_fs.py
+++ b/_damo_fs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import os

--- a/_damo_paddr_layout.py
+++ b/_damo_paddr_layout.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import argparse

--- a/_damo_python2_support.py
+++ b/_damo_python2_support.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import os

--- a/_damo_subcmds.py
+++ b/_damo_subcmds.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import argparse

--- a/_damon.py
+++ b/_damon.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/_damon_args.py
+++ b/_damon_args.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/_damon_args_schemes.py
+++ b/_damon_args_schemes.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/_damon_dbgfs.py
+++ b/_damon_dbgfs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/_damon_result.py
+++ b/_damon_result.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import collections

--- a/_damon_sysfs.py
+++ b/_damon_sysfs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/damo_adjust.py
+++ b/damo_adjust.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 "Adjust a damon monitoring result with new attributes"

--- a/damo_features.py
+++ b/damo_features.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import json

--- a/damo_fmt_json.py
+++ b/damo_fmt_json.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/damo_heats.py
+++ b/damo_heats.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/damo_lru_sort.py
+++ b/damo_lru_sort.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 "Control DAMON_LRU_SORT"

--- a/damo_monitor.py
+++ b/damo_monitor.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 "Record and report data access pattern in realtime"

--- a/damo_nr_regions.py
+++ b/damo_nr_regions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 "Print out distribution of the number of regions in the given record"

--- a/damo_reclaim.py
+++ b/damo_reclaim.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 "Control DAMON_RECLAIM"

--- a/damo_record.py
+++ b/damo_record.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/damo_report.py
+++ b/damo_report.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import argparse

--- a/damo_report_json.py
+++ b/damo_report_json.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import argparse

--- a/damo_report_raw.py
+++ b/damo_report_raw.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import argparse

--- a/damo_schemes.py
+++ b/damo_schemes.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/damo_start.py
+++ b/damo_start.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/damo_stat.py
+++ b/damo_stat.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import signal

--- a/damo_stat_kdamonds.py
+++ b/damo_stat_kdamonds.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import argparse

--- a/damo_stat_regions.py
+++ b/damo_stat_regions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import argparse

--- a/damo_stat_schemes.py
+++ b/damo_stat_schemes.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 import argparse

--- a/damo_stop.py
+++ b/damo_stop.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/damo_translate_damos.py
+++ b/damo_translate_damos.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/damo_tune.py
+++ b/damo_tune.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 """

--- a/damo_validate.py
+++ b/damo_validate.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 "Validate a given damo-record result file"

--- a/damo_wss.py
+++ b/damo_wss.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0
 
 "Print out the distribution of the working set sizes of the given trace"


### PR DESCRIPTION
These are not meant to be launched, they should not have shebangs

cf. Fedora package review https://bugzilla.redhat.com/show_bug.cgi?id=2203480#c4

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
