### PR TITLE
damo_schemes: Fix undefined 'err' in cleanup_exit

### DIFF
--- a/damo_schemes.py
+++ b/damo_schemes.py
@@ -12,7 +12,7 @@ import _damon_args
 
 def cleanup_exit(exit_code):
     # ignore returning error, as kdamonds may already finished
-    _damon.turn_damon_off(kdamonds_idxs)
+    err = _damon.turn_damon_off(kdamonds_idxs)
     if err:
         print('failed to turn damon off (%s)' % err)
     err = _damon.stage_kdamonds(orig_kdamonds)


### PR DESCRIPTION
This patch is to fix the following error in cleanup_exit().
```
  NameError: name 'err' is not defined
```