### PR TITLE
Preserve timestamps when packaging

### DIFF
--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -37,7 +37,7 @@ bindir=$(dirname "$0")
 
 for file in "setup.py" "pyproject.toml"
 do
-	cp "$bindir/$file" "$work_dir/"
+	cp -p "$bindir/$file" "$work_dir/"
 done
 
 "$bindir/mk_readme.sh" "$work_dir" "$version"
@@ -45,8 +45,8 @@ done
 damo_dir="$bindir/.."
 
 mkdir -p "$work_dir/src/damo"
-cp "$damo_dir/"*.py "$work_dir/src/damo"
-cp "$damo_dir/damo" "$work_dir/src/damo/damo.py"
+cp -p "$damo_dir/"*.py "$work_dir/src/damo"
+cp -p "$damo_dir/damo" "$work_dir/src/damo/damo.py"
 touch "$work_dir/src/damo/__init__.py"
 
 cd "$work_dir"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`cp` should be called with `-p` to preserve timestamps so that builds are more reproducible


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
