### PR TITLE
Document DAMO availability in Linux distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ http://www.youtube.com/watch?v=l63eqbVBZRY
 Getting Started
 ===============
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/damo.svg)](https://repology.org/project/damo/versions)
+
 Follow below instructions and commands to monitor and visualize the access
 pattern of your workload.
 
     $ # ensure your kernel is built with CONFIG_DAMON_*=y
+    $ # install from PyPI, or use your distribution's package manager
     $ sudo pip3 install damo
     $ sudo damo record $(pidof <your workload>)
     $ damo report heats --heatmap stdout --stdout_heatmap_color emotion


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
DAMO is now packaged in Fedora and Debian (and thus also Debian derivatives like Devuan and Ubuntu), and it turns out it's also already packaged in Arch Linux's AUR as well as AOSC.

Show the SVG from Repology and mention that it can be installed using the relevant distribution package manager.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
