### PR TITLE
show: status: Print addr info in hex format

### DIFF
--- a/_damo_fmt_str.py
+++ b/_damo_fmt_str.py
@@ -34,10 +34,12 @@ def format_sz(sz_bytes, machine_friendly):
         return '%.3f KiB' % (sz_bytes / (1<<10))
     return '%d B' % sz_bytes
 
+def format_addr(addr):
+    return str('%08x' % addr)
+
 def format_addr_range(start, end, machine_friendly):
     return '[%s, %s) (%s)' % (
-            format_nr(start, machine_friendly),
-            format_nr(end, machine_friendly),
+            format_addr(start), format_addr(end),
             format_sz(end - start, machine_friendly))
 
 ns_ns = 1

--- a/damo_show.py
+++ b/damo_show.py
@@ -28,9 +28,9 @@ region_formatters = {
         '<index>': lambda index, region, raw:
             _damo_fmt_str.format_nr(index, raw),
         '<start address>': lambda index, region, raw:
-            _damo_fmt_str.format_sz(region.start, raw),
+            _damo_fmt_str.format_addr(region.start),
         '<end address>': lambda index, region, raw:
-            _damo_fmt_str.format_sz(region.end, raw),
+            _damo_fmt_str.format_addr(region.end),
         '<region size>': lambda index, region, raw:
             _damo_fmt_str.format_sz(region.size(), raw),
         '<access rate>': lambda index, region, raw:


### PR DESCRIPTION
The current output of damo show and status do not print address info in hex format. It makes the address comparison with other format difficult.

This patch makes printing address info in hex format.

Before:
```
  # ./damo show
  0   addr [4.000 GiB   , 5.299 GiB  ) (1.299 GiB  ) access 0 %   age 29 s
  1   addr [5.299 GiB   , 6.594 GiB  ) (1.295 GiB  ) access 0 %   age 2 m 12.300 s
  2   addr [6.594 GiB   , 7.892 GiB  ) (1.299 GiB  ) access 0 %   age 2 m 12.300 s
      ...
```
After:
```
  $ ./damo show
  0   addr [100000000   , 1531b7000  ) (1.299 GiB  ) access 0 %   age 29.100 s
  1   addr [1531b7000   , 1a5ff6000  ) (1.295 GiB  ) access 0 %   age 36.900 s
  2   addr [1a5ff6000   , 1f91e4000  ) (1.299 GiB  ) access 0 %   age 36.900 s
      ...
```