### PR TITLE
show: Reverse the order of damo show --sort_regions_by

### DIFF
--- a/damo_show.py
+++ b/damo_show.py
@@ -205,11 +205,11 @@ def sorted_regions(regions, sort_fields):
         if field == 'address':
             regions = sorted(regions, key=lambda r: r.start)
         elif field == 'access_rate':
-            regions = sorted(regions, key=lambda r: r.nr_accesses.percent)
+            regions = sorted(regions, key=lambda r: r.nr_accesses.percent, reverse=True)
         elif field == 'age':
-            regions = sorted(regions, key=lambda r: r.age.usec)
+            regions = sorted(regions, key=lambda r: r.age.usec, reverse=True)
         elif field == 'size':
-            regions = sorted(regions, key=lambda r: r.size())
+            regions = sorted(regions, key=lambda r: r.size(), reverse=True)
     return regions
 
 def pr_records(args, records):


### PR DESCRIPTION
The current sort order of `--sort_regions_by` option in `damo show` is a ascending order and it shows the most interesting result at the bottom.

However, users might want to see the most interesting regions at the top. For example, it could be most accessed regions.

So it might be better to reverse the sort order from ascending to descending order as follows.

Before:
```
  $ ./damo show --sort_regions_by access_rate
  0   addr [4.000 gib   , 4.549 gib  ) (562.312 mib) access 0 %   age 600 ms
  1   addr [4.744 gib   , 6.024 gib  ) (1.280 gib  ) access 0 %   age 500 ms
  2   addr [6.024 gib   , 7.306 gib  ) (1.282 gib  ) access 0 %   age 600 ms
  3   addr [7.306 gib   , 8.595 gib  ) (1.289 gib  ) access 0 %   age 500 ms
  4   addr [8.595 gib   , 9.871 gib  ) (1.276 gib  ) access 0 %   age 300 ms
  5   addr [9.871 gib   , 17.000 gib ) (7.129 gib  ) access 0 %   age 200 ms
  6   addr [4.549 gib   , 4.686 gib  ) (139.965 mib) access 60 %  age 0 ns
  7   addr [4.686 gib   , 4.744 gib  ) (59.988 mib ) access 70 %  age 0 ns
  total size: 13.000 gib
```
After:
```
  $ ./damo show --sort_regions_by access_rate
  0   addr [4.686 gib   , 4.744 gib  ) (59.988 mib ) access 70 %  age 0 ns
  1   addr [4.549 gib   , 4.686 gib  ) (139.965 mib) access 60 %  age 0 ns
  2   addr [9.871 gib   , 17.000 gib ) (7.129 gib  ) access 0 %   age 200 ms
  3   addr [8.595 gib   , 9.871 gib  ) (1.276 gib  ) access 0 %   age 300 ms
  4   addr [7.306 gib   , 8.595 gib  ) (1.289 gib  ) access 0 %   age 500 ms
  5   addr [6.024 gib   , 7.306 gib  ) (1.282 gib  ) access 0 %   age 600 ms
  6   addr [4.744 gib   , 6.024 gib  ) (1.280 gib  ) access 0 %   age 500 ms
  7   addr [4.000 gib   , 4.549 gib  ) (562.312 mib) access 0 %   age 600 ms
  total size: 13.000 gib
```
This patch reverses the sort order for 'access_rate', 'age', and 'size' but not for 'address'.