### PR TITLE
_damon_sysfs: Allow enabling two or more kdamonds

### DIFF
--- a/_damon_sysfs.py
+++ b/_damon_sysfs.py
@@ -305,8 +305,6 @@ def ensure_dirs_populated_for(kdamonds):
         exit(1)
 
 def stage_kdamonds(kdamonds):
-    if len(kdamonds) > 1:
-        return 'currently only <=one kdamond is supported'
     if len(kdamonds) == 1 and len(kdamonds[0].contexts) > 1:
         return 'currently only <=one damon_ctx is supported'
     ensure_dirs_populated_for(kdamonds)


### PR DESCRIPTION
The current implementation blocks creating two or more kdamonds using config json file.

It currently fails as follows.
```
  $ ./damo start two_kdamonds.json
  could not turn on damon (cannot apply kdamonds from args (currently only <=one kdamond is supported))
```
This patch simply removes the check routine and there is no problem creating two kdamonds using the config json file.
```
  $ ./damo start two_kdamonds.json

  $ tree -L 2 /sys/kernel/mm/damon/admin/kdamonds
  /sys/kernel/mm/damon/admin/kdamonds
  |-- 0
  |   |-- contexts
  |   |-- pid
  |   `-- state
  |-- 1
  |   |-- contexts
  |   |-- pid
  |   `-- state
  `-- nr_kdamonds

  $ ps aux | grep kdamond
  root      3138  0.0  0.0      0     0 ?        I    04:04   0:00
  [kdamond.0]
  root      3139  0.0  0.0      0     0 ?        I    04:04   0:00
  [kdamond.1]
```
Closes: #76