### PR TITLE
_damo_paddr_layout.py: Handle System RAM (kmem)

### DIFF
--- a/_damo_paddr_layout.py
+++ b/_damo_paddr_layout.py
@@ -145,7 +145,7 @@ def default_paddr_region():
             if len(fields) != 2:
                 continue
             name = fields[1].strip()
-            if name != 'System RAM':
+            if not name.startswith('System RAM'):
                 continue
             addrs = fields[0].split('-')
             if len(addrs) != 2:
@@ -162,7 +162,7 @@ def paddr_region_of(numa_node):
     regions = []
     paddr_ranges_ = paddr_ranges()
     for r in paddr_ranges_:
-        if r.nid == numa_node and r.name == 'System RAM':
+        if r.nid == numa_node and r.name.startswith('System RAM'):
             regions.append([r.start, r.end])
 
     return regions


### PR DESCRIPTION
As shown in the kernel commit at [1], there could be "System RAM" with "(kmem)" postfix as follows.
```
  [root@localhost ~]# cat /proc/iomem
  ...
  140000000-33fffffff : Persistent Memory
    140000000-1481fffff : namespace0.0
    150000000-33fffffff : dax0.0
      150000000-33fffffff : System RAM (kmem)
```
But the current comparison logic does not handle this case as it tries exact match only.

So this patch changes "System RAM" string match logic to handle this case as well.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8a725e4694b52ffad755500277d36f3b2eb34755
Signed-off-by: Honggyu Kim <honggyu.kim@sk.com>