### PR TITLE
tests: schemes: test.sh: Python version included

### DIFF
--- a/tests/schemes/test.sh
+++ b/tests/schemes/test.sh
@@ -24,7 +24,7 @@ __test_stat() {
 		local quota_reset_interval="max"
 	fi
 
-	python ./stairs.py &
+	python3 ./stairs.py &
 	local stairs_pid=$!
 	sudo "$damo" start "$stairs_pid" --damos_action stat \
 		--damos_sz_region 4K max --damos_access_rate 0% 0% \


### PR DESCRIPTION
While running `sudo ./test/run.sh` encountered the error due to python version. Following was the error.
```
./schemes/test.sh: line 27: python: command not found
could not turn on damon (writing on to /sys/kernel/mm/damon/admin/kdamonds/0/state
failed ([Errno 22] Invalid argument))
./schemes/test.sh: line 45: test_stat_applied / (SECONDS - start_time): division
by 0 (error token is "(SECONDS - start_time)")
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
