### PR TITLE
tests/start_stop: Set smaller aggr interval for tune-record-ongoing-validate

### DIFF
--- a/tests/start_stop/test.sh
+++ b/tests/start_stop/test.sh
@@ -97,7 +97,7 @@ do
 	fi
 	sudo timeout 3 "$damo" record ongoing \
 		--damon_interface_DEPRECATED "$damon_interface" &> /dev/null
-	if ! "$damo" validate --aggr 180000 220000 2> /dev/null
+	if ! "$damo" validate --aggr 180000 220000 --nr_accesses 0 44 2> /dev/null
 	then
 		echo "FAIL $testname2 (invalid record file after tune)"
 		if ! sudo "$damo" stop


### PR DESCRIPTION
**Description of changes:**
Default limit for nr_accesses is [0,24] so max aggr interval can be 100ms for 5ms sample interval.

We are reducing the aggregation interval from 200ms to 80ms when tuning the damo. This helps us to avoid `start_stop` test failure at [L81 in validate.py](https://github.com/awslabs/damo/blob/next/damo_validate.py#L81).

**Test results:**

_Env_
Amazon Linux 2023 - ami-05295b6e6c790593e (6.1.79-99.167.amzn2023.x86_64), ap-south-1.

_Before the patch_
```
$ sudo ./tests/run.sh 
PASS unit test_damo_scheme_dbgfs_conversion.py
PASS unit test_damo_schemes_input.py
PASS unit test_damo_show.py
<snipped>
<snipped>
PASS damon_lru_sort
PASS start_stop sysfs start
PASS start_stop sysfs record-ongoing-validate
PASS start_stop sysfs status 10
invalid: expect 0<=nr_accesses<=24 but 38
FAIL start_stop sysfs (invalid record file after tune)
$ 
```
_After the patch_
```
$ sudo ./tests/run.sh 
PASS unit test_damo_scheme_dbgfs_conversion.py
PASS unit test_damo_schemes_input.py
PASS unit test_damo_show.py
<snipped>
<snipped>
PASS schemes
PASS damon_reclaim
PASS damon_lru_sort
PASS start_stop sysfs start
PASS start_stop sysfs record-ongoing-validate
PASS start_stop sysfs status 10
PASS start_stop sysfs tune-record-ongoing-validate
PASS start_stop sysfs tune-status 10
PASS start_stop sysfs stop
PASS start_stop
PASS ALL
$
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.