### PR TITLE
damo_tune: Ensure reset interval is specified for quota-goals

### DIFF
--- a/damo_tune.py
+++ b/damo_tune.py
@@ -7,15 +7,30 @@ Update DAMON input parameters.
 import _damon
 import _damon_args
 
-def evaluate_args_for_quota_goals(args):
-    if args.damos_action:
-        return True, None
-    
-    for key, value in args.__dict__.items():
-        if key.startswith('damos_') and len(value):
-            if key == 'damos_action': continue
-            return False, 'no \'damos_action\' provided in arguments while using --damos_* option(s)'
+def evaluate_args_for_tune(args):
+    '''
+    Verify if 'damons_action' is present when any 'damos_*' is specified
+    '''
+    if not args.damos_action:
+        for key, value in args.__dict__.items():
+            if key.startswith('damos_') and len(value):
+                if key == 'damos_action': continue
+                return False, '\'damos_action\' not specified while using --damos_* option(s)'
 
+    '''
+    Verify if 'reset_interval_ms' is specified in args when setting quota goals
+    '''
+    if args.damos_quota_goal:
+        damos_quotas = args.damos_quotas
+
+        if not len(damos_quotas):
+            return False, '\'reset_interval_ms\' not specified when setting quota goals'
+
+        #reset_interval_ms is specified in --damos_quotas as 3rd arg
+        for quota in damos_quotas:
+            if len(quota) < 3:
+                return False, '\'reset_interval_ms\' not specified when setting quota goals'
+    
     return True, None
 
 def main(args):
@@ -25,7 +40,7 @@ def main(args):
         print('DAMON is not turned on')
         exit(1)
 
-    correct_args, err = evaluate_args_for_quota_goals(args)
+    correct_args, err = evaluate_args_for_tune(args)
 
     if (correct_args is not True and err is not None):
         print('Tune error: incorrect arguments: %s' % err)


### PR DESCRIPTION
*Description of changes:*

While tuning, if user provides 'damos_quota_goal' and not 'reset_interval_ms', throw an error.

*Testing:*
$ ./tests/run.sh
ALL passed

*Error preview:*
```
[root@ip-172-31-36-123 damo]# damo tune --damos_action pageout --damos_quotas 30 --damos_quota_goal user_input 60 30 --ops vaddr --debug_damon
read '/sys/kernel/mm/damon/admin/kdamonds/nr_kdamonds': '1'
read '/sys/kernel/mm/damon/admin/kdamonds/0/state': 'on'
Tune error: incorrect arguments: 'reset_interval_ms' not specified when setting quota goals
[root@ip-172-31-36-123 damo]# 
```
