### PR TITLE
_damo_fs: compare with s_subtype instead for mnt_devname

### DIFF
--- a/_damo_fs.py
+++ b/_damo_fs.py
@@ -69,7 +69,7 @@ def dev_mount_point(dev):
     '''Returns mount point of specific device.  None if not mounted'''
     with open('/proc/mounts', 'r') as f:
         for line in f:
-            dev_name, mount_point = line.split()[:2]
-            if dev_name == dev:
+            dev_name, mount_point, dev_fs = line.split()[:3]
+            if dev_fs == dev:
                 return mount_point
     return None


### PR DESCRIPTION
In case of _sysfs_ its `/proc/mounts` entry looks different from _debugfs_:
```sh
sys /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
```
It may have `sys` as `mnt_devname` (a.k.a `dev_name`), so searching for it with `sysfs` gives no result.