### PR TITLE
pre-commit: Add automatic unittest script run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,11 @@ repos:
     hooks:
     -   id: codespell
         args: ['-I', '.codespell_ignore']
+-   repo: local
+    hooks:
+    -   id: unit-test-run
+        name: ./tests/unit/test.sh
+        entry: ./tests/unit/test.sh
+        language: system
+        files: \.py$
+        pass_filenames: false


### PR DESCRIPTION
The PR #100 supports "target_nid" for migrate actions, but it didn't handle the unit test properly.

It's because running unit test at ./tests/unit/test.sh is recommended at CONTRIBUTING file, but it's not enforced before making PRs.

This patch make each commit prevent from breaking unittest unexpectedly by having a dedicated pre-commit hook that runs ./tests/unit/test.sh when .py files are modified.

The following log shows when test_damo_schemes_input.py is broken as the PR #100 made the issue.
```
  check yaml...............................................................Passed
  fix end of files.........................................................Passed
  trim trailing whitespace.................................................Passed
  isort................................................(no files to check)Skipped
  codespell................................................................Passed
  ./tests/unit/test.sh.....................................................Failed
  - hook id: unit-test
  - exit code: 1

  PASS unit test_damo_records.py
  PASS unit test_damo_scheme_dbgfs_conversion.py
  FAIL unit test_damo_schemes_input.py
```
This was fixed by the commit below, but just roll backed to one before this commit to see whether the pre-commit hook runs properly showing the issue.

  79d0d69 tests/unit/test_damo_schemes_input: Fix wrong Damos constructor call