### PR TITLE
show: Throw clear error message on unsupported kernels

### DIFF
--- a/src/_damon_sysfs.py
+++ b/src/_damon_sysfs.py
@@ -74,7 +74,10 @@ def update_schemes_tried_bytes(kdamond_idxs):
 def update_schemes_tried_regions(kdamond_idxs):
     err = __write_state_file(kdamond_idxs, 'update_schemes_tried_regions')
     if err != None:
-        err = '%s (maybe schemes_tried_regions not supported?)' % err
+        if not feature_supported('schemes_tried_regions'):
+            err = '%s (DAMON feature \'schemes_tried_regions\' is not supported on the current kernel. It is available on kernel version 6.2 and later)' % err
+        else:
+            err = '%s (concurrent threads doing writes)' % err
     return err
 
 'Return error'


### PR DESCRIPTION
'schemes_tried_regions' is only available from v6.2

Fixes issue #101

*Description of changes:*

Env:
```
[root@ip-172-31-7-19 damo]# uname -r
6.1.82-99.168.amzn2023.x86_64
[root@ip-172-31-7-19 damo]# damo start 
[root@ip-172-31-7-19 damo]# damo features | grep schemes_tried_regions
schemes_tried_regions: Unsupported
schemes_tried_regions_sz: Unsupported
[root@ip-172-31-7-19 damo]# 
```

Before:
```
[root@ip-172-31-7-19 damo]# damo show
updating schemes tried regions fail: writing update_schemes_tried_regions to /sys/kernel/mm/damon/admin/kdamonds/0/state failed ([Errno 22] Invalid argument) (maybe schemes_tried_regions not supported?)
[root@ip-172-31-7-19 damo]# 
```

After:

```
[root@ip-172-31-7-19 damo]# damo show
updating schemes tried regions fail: writing update_schemes_tried_regions to /sys/kernel/mm/damon/admin/kdamonds/0/state failed ([Errno 22] Invalid argument) (DAMON feature 'schemes_tried_regions' is supported only from kernel version 6.2)
[root@ip-172-31-7-19 damo]# 
```

*Testing:*
```
[root@ip-172-31-7-19 damo]# ./tests/run.sh 
PASS unit test_damo_records.py
PASS unit test_damo_scheme_dbgfs_conversion.py
PASS unit test_damo_schemes_input.py
[...]
[...]
PASS start_stop sysfs stop
PASS start_stop
PASS ALL
[root@ip-172-31-7-19 damo]#
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
